### PR TITLE
Prepare next development version 0.0.2-SNAPSHOT

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "Audio Analyzer",
   "upload_type": "software",
-  "description": "Audio Analyzer is a Java 21 research platform for reproducible acoustic analysis, digital signal processing experiments, dataset analysis, benchmarking and experimental acoustic localization workflows.",
+  "description": "Audio Analyzer is a Java 21 research platform for reproducible acoustic analysis, digital signal processing experiments, dataset analysis, benchmarking and experimental acoustic localization workflows. It provides a modular Maven architecture with core audio-domain types, DSP analyzers, recording and evidence export, plugin contracts, and an experimental acoustic-localization module for microphone-array research.",
   "creators": [
     {
       "name": "Hammer, Carsten",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "Audio Analyzer",
   "upload_type": "software",
-  "description": "Audio Analyzer is a Java 21 research platform for reproducible acoustic analysis, digital signal processing experiments, dataset analysis, benchmarking and experimental acoustic localization workflows. It provides a modular Maven architecture with core audio-domain types, DSP analyzers, recording and evidence export, plugin contracts, and an experimental acoustic-localization module for microphone-array research.",
+  "description": "Audio Analyzer is a Java 21 research platform for reproducible acoustic analysis, digital signal processing experiments, dataset analysis, benchmarking and experimental acoustic localization workflows.",
   "creators": [
     {
       "name": "Hammer, Carsten",
@@ -30,6 +30,6 @@
       "scheme": "url"
     }
   ],
-  "version": "0.0.1-SNAPSHOT",
+  "version": "0.0.2-SNAPSHOT",
   "language": "eng"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ abstract: >-
   digital signal processing experiments, dataset analysis, benchmarking and
   experimental acoustic localization workflows.
 license: MIT
-version: "0.0.1-SNAPSHOT"
+version: "0.0.2-SNAPSHOT"
 keywords:
   - audio-analysis
   - acoustic-localization

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Requires **Java 21** or higher. The Maven Wrapper is included.
 ./mvnw clean verify
 
 # Run the Swing app after package/verify
-java -jar audio-app/target/audio-app-0.0.1-SNAPSHOT.jar
+java -jar audio-app/target/audio-app-0.0.2-SNAPSHOT.jar
 
 # Regenerate README + feature screenshots headlessly
-java -cp "audio-app/target/audio-app-0.0.1-SNAPSHOT.jar:audio-app/target/lib/*" \
+java -cp "audio-app/target/audio-app-0.0.2-SNAPSHOT.jar:audio-app/target/lib/*" \
   org.hammer.tools.DocImageRenderer docs/images
 
 # Optional JMH benchmarks

--- a/audio-acquisition/pom.xml
+++ b/audio-acquisition/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>audioin</groupId>
     <artifactId>audioin-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>audio-acquisition</artifactId>
   <name>Audio Analyzer Acquisition</name>

--- a/audio-app/pom.xml
+++ b/audio-app/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>audioin</groupId>
     <artifactId>audioin-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>audio-app</artifactId>
   <name>Audio Analyzer App</name>

--- a/audio-core/pom.xml
+++ b/audio-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>audioin</groupId>
     <artifactId>audioin-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>audio-core</artifactId>
   <name>Audio Analyzer Core</name>

--- a/audio-dsp/pom.xml
+++ b/audio-dsp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>audioin</groupId>
     <artifactId>audioin-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>audio-dsp</artifactId>
   <name>Audio Analyzer DSP and Analysis</name>

--- a/audio-experimental-acoustic/pom.xml
+++ b/audio-experimental-acoustic/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>audioin</groupId>
     <artifactId>audioin-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>audio-experimental-acoustic</artifactId>
   <name>Audio Analyzer Experimental Acoustic</name>

--- a/audio-geometry/pom.xml
+++ b/audio-geometry/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>audioin</groupId>

--- a/audio-geometry/pom.xml
+++ b/audio-geometry/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>audioin</groupId>

--- a/audio-geometry/pom.xml
+++ b/audio-geometry/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>audioin</groupId>

--- a/audio-geometry/pom.xml
+++ b/audio-geometry/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>audioin</groupId>
     <artifactId>audioin-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>audio-geometry</artifactId>
   <name>Audio Analyzer Geometry</name>

--- a/audio-plugin-api/pom.xml
+++ b/audio-plugin-api/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>audioin</groupId>

--- a/audio-plugin-api/pom.xml
+++ b/audio-plugin-api/pom.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>audioin</groupId>
     <artifactId>audioin-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>audio-plugin-api</artifactId>
   <name>Audio Analyzer Plugin API</name>
-  <description>Stable plugin contracts (descriptors, contributions, plugin interface) between the
-    Audio Analyzer host application and optional plugins. Contains API only, no Swing UI,
-    no JavaSound and no concrete plugin implementations.</description>
+  <description>Stable plugin contracts between the Audio Analyzer host application and optional plugins.</description>
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/audio-plugin-api/pom.xml
+++ b/audio-plugin-api/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>audioin</groupId>

--- a/audio-plugin-api/pom.xml
+++ b/audio-plugin-api/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>audioin</groupId>
@@ -8,7 +8,9 @@
   </parent>
   <artifactId>audio-plugin-api</artifactId>
   <name>Audio Analyzer Plugin API</name>
-  <description>Stable plugin contracts between the Audio Analyzer host application and optional plugins.</description>
+  <description>Stable plugin contracts (descriptors, contributions, plugin interface) between the
+    Audio Analyzer host application and optional plugins. Contains API only, no Swing UI,
+    no JavaSound and no concrete plugin implementations.</description>
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/docs/audio-and-threading.md
+++ b/docs/audio-and-threading.md
@@ -123,7 +123,7 @@ The application uses `java.util.logging` for diagnostics.
 
 ```bash
 java -Djava.util.logging.config.file=logging.properties \
-     -jar audio-app/target/audio-app-0.0.1-SNAPSHOT.jar
+     -jar audio-app/target/audio-app-0.0.2-SNAPSHOT.jar
 ```
 
 `logging.properties`:
@@ -137,4 +137,3 @@ java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 ```
 
 > Avoid enabling `FINE` in production; it generates substantial output during real-time capture.
-

--- a/docs/audio-and-threading.md
+++ b/docs/audio-and-threading.md
@@ -137,3 +137,4 @@ java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 ```
 
 > Avoid enabling `FINE` in production; it generates substantial output during real-time capture.
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,10 +31,10 @@ Artifacts use a fixed `project.build.outputTimestamp`, so repeated builds from t
 
 ```bash
 ./mvnw clean package
-sha256sum audio-app/target/audio-app-0.0.1-SNAPSHOT.jar
+sha256sum audio-app/target/audio-app-0.0.2-SNAPSHOT.jar
 
 ./mvnw clean package
-sha256sum audio-app/target/audio-app-0.0.1-SNAPSHOT.jar
+sha256sum audio-app/target/audio-app-0.0.2-SNAPSHOT.jar
 # Both checksums must match.
 ```
 
@@ -105,7 +105,7 @@ The README and feature screenshots are generated headlessly by `DocImageRenderer
 verify build:
 
 ```bash
-java -cp "audio-app/target/audio-app-0.0.1-SNAPSHOT.jar:audio-app/target/lib/*" \
+java -cp "audio-app/target/audio-app-0.0.2-SNAPSHOT.jar:audio-app/target/lib/*" \
   org.hammer.tools.DocImageRenderer docs/images
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>audioin</groupId>
   <artifactId>audioin-parent</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Audio Analyzer Parent</name>


### PR DESCRIPTION
Follow-up after release 0.0.1.

This PR moves the repository back to the next development snapshot without creating or modifying the already published 0.0.1 release.

Changes:
- Bump root Maven project to 0.0.2-SNAPSHOT
- Bump module parent versions to 0.0.2-SNAPSHOT
- Update CITATION.cff to 0.0.2-SNAPSHOT
- Update .zenodo.json to 0.0.2-SNAPSHOT
- Keep release-only publication date metadata out of the development snapshot

Note: the existing GitHub/Zenodo release 0.0.1 should be treated as final and should not be re-run.