### PR TITLE
Add Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![CodeQL](https://github.com/carstenartur/audio-analyzer/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/carstenartur/audio-analyzer/actions/workflows/codeql.yml)
 [![License](https://img.shields.io/github/license/carstenartur/audio-analyzer)](LICENSE)
 [![SBOM](https://img.shields.io/badge/SBOM-CycloneDX-informational?logo=owasp)](https://github.com/carstenartur/audio-analyzer/dependency-graph/sbom)
+[![DOI](https://zenodo.org/badge/7397122.svg)](https://zenodo.org/badge/latestdoi/7397122)
 
 **Audio Analyzer** is a Java 21 / Swing **research platform for acoustic analysis and
 localization**. It provides reproducible benchmarking, dataset analysis, feature engineering,


### PR DESCRIPTION
Adds the Zenodo DOI badge to the README after the 0.0.1 release was published.

This does not create or modify any GitHub or Zenodo release; it only exposes the existing DOI in the project README.