### PR TITLE
Add ORCID to CITATION.md

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -31,3 +31,4 @@ Carsten Hammer's ORCID iD is [https://orcid.org/0009-0005-1047-6381](https://orc
 - Cite the Zenodo DOI for stable archival reference once available.
 - Cite the GitHub repository when referring to the active development version.
 - Cite specific commits or release tags when reproducibility depends on the exact implementation state.
+

--- a/CITATION.md
+++ b/CITATION.md
@@ -13,6 +13,7 @@ When a Zenodo DOI is minted for a release, prefer the Zenodo citation shown on t
 ```bibtex
 @software{hammer_audio_analyzer_2026,
   author       = {Hammer, Carsten},
+  orcid        = {https://orcid.org/0009-0005-1047-6381},
   title        = {Audio Analyzer},
   version      = {0.0.3-SNAPSHOT},
   publisher    = {GitHub and Zenodo},
@@ -23,11 +24,10 @@ When a Zenodo DOI is minted for a release, prefer the Zenodo citation shown on t
 
 ## Author identifier
 
-Carsten Hammer's ORCID iD is https://orcid.org/0009-0005-1047-6381.
+Carsten Hammer's ORCID iD is [https://orcid.org/0009-0005-1047-6381](https://orcid.org/0009-0005-1047-6381).
 
 ## What to cite
 
 - Cite the Zenodo DOI for stable archival reference once available.
 - Cite the GitHub repository when referring to the active development version.
 - Cite specific commits or release tags when reproducibility depends on the exact implementation state.
-


### PR DESCRIPTION
## Summary

- add the ORCID iD to the BibTeX block in `CITATION.md`
- convert the author identifier into a clickable ORCID link

## Context

The release metadata helper already updates `CITATION.md`; this PR brings the current checked-in file in line with the helper's ORCID-aware output.