### PR TITLE
Document versioned collaborative workflow store architecture

### DIFF
--- a/docs/architecture/adr-006-versioned-collaborative-workflow-store.md
+++ b/docs/architecture/adr-006-versioned-collaborative-workflow-store.md
@@ -1,0 +1,109 @@
+# ADR-006: Versioned collaborative workflow store
+
+Status: Accepted with spike gates  
+Date: 2026-07-05
+
+## Context
+
+Audio Analyzer already contains a stable workflow domain in `audio-core`. The current architecture separates design-time workflow objects from execution state and records edits as semantic workflow operations. That is the right foundation for a future graphical workflow editor with replay, undo and collaborative editing.
+
+Taxonomy, Sandbox and the JGit fork also show that DB-backed Git storage through JGit and Hibernate is a useful platform capability. It should not be copied again into Audio Analyzer as project-local infrastructure.
+
+The desired future capability is a graphical workflow editor where users can choose whether they work privately or live with other users on the same drawing. In live sessions, undo may be personal or explicitly shared.
+
+## Decision
+
+Audio Analyzer will use the existing workflow model as the audio-domain basis and add a versioned, collaborative workflow-store layer around it.
+
+The Hibernate-backed JGit store will be consolidated as a separate reusable infrastructure module or repository, tentatively named `jgit-storage-hibernate` or `hibernate-jgit-store`. Audio Analyzer will use that store through a narrow persistence facade and must not depend directly on JGit internals such as `org.eclipse.jgit.internal.*`.
+
+The default strategy is **not** to fork JGit for Audio Analyzer. A JGit fork is only acceptable if a dedicated spike proves that upstream JGit cannot support the required transactional semantics through the available DFS/Reftable extension points.
+
+## Architectural shape
+
+```text
+Web graph editor / desktop bridge
+    -> workflow application service
+    -> workflow operation log
+    -> audio workflow domain model
+    -> deterministic workflow DSL
+    -> versioned workflow persistence facade
+    -> jgit-storage-hibernate
+    -> database-backed JGit objects/refs/reflog
+    -> Hibernate Search projections
+    -> transactional outbox
+    -> event broker / WebSocket clients
+```
+
+## Collaboration modes
+
+The editor must support explicit collaboration modes:
+
+```text
+PRIVATE_WORKSPACE
+    Only the actor sees their current changes.
+    Undo/redo is personal.
+    Changes are published or merged explicitly.
+
+SHARED_SESSION_PERSONAL_UNDO
+    Participants see the same live drawing.
+    Each participant's undo stack contains only their own undoable operations.
+    This is the recommended default for live collaboration.
+
+SHARED_SESSION_SHARED_UNDO
+    Participants share one room-level undo stack.
+    Undo can revert another user's operation and therefore must be explicit in the UI.
+```
+
+Undo and redo are represented as semantic operations. Git commits are durable history checkpoints, not the local editor undo stack.
+
+## Web editor decision
+
+The collaborative graphical editor should be developed web-first, but the existing Swing application should not be rewritten in one step. A web editor can later be hosted as a browser UI, a desktop WebView, or a dedicated module.
+
+GLSP is the preferred architecture spike for the serious model-driven editor path because the server can remain authoritative over the semantic source model. A simpler React Flow prototype remains useful for UX validation, but it must not become the canonical workflow state by accident.
+
+## Event transport decision
+
+The event broker is transport, not source of truth. ActiveMQ Artemis or another broker may be used behind an abstraction, but persistence must follow a transactional outbox pattern:
+
+```text
+DB transaction:
+  append workflow operation
+  update model/checkpoint/ref/projections
+  insert outbox event
+commit
+
+outbox dispatcher:
+  publish committed event to broker/WebSocket clients
+```
+
+## Consequences
+
+Positive:
+
+- avoids a third copy of the JGit/Hibernate storage idea;
+- keeps Audio Analyzer focused on audio workflow semantics;
+- preserves the existing workflow operation model;
+- prepares multi-user editing without forcing an immediate Swing rewrite;
+- lets Taxonomy, Sandbox and Audio Analyzer converge on one storage component.
+
+Costs and risks:
+
+- the storage spike becomes a required prerequisite;
+- JGit internal API usage must be isolated and version-pinned;
+- collaboration requires a persisted operation log, outbox and conflict policy;
+- shared undo must be opt-in because it can revert another user's work.
+
+## Spike gates
+
+This ADR is accepted only with the following gates:
+
+1. **JGit storage gate**: prove whether a separate Hibernate-backed storage module can compile and run against a regular JGit release without core patches.
+2. **Transactional gate**: prove that blob/tree/commit writes, ref updates, operation log entries and outbox events can be made atomically consistent.
+3. **Workflow gate**: prove a minimal `Input -> Gain -> Output` workflow roundtrip through domain model, DSL, DB-backed Git commit, search projection and reload.
+4. **Collaboration gate**: prove private mode and a shared-session undo mode with at least two simulated clients.
+
+## Follow-up
+
+The next implementation item is the JGit/Hibernate storage spike, documented in `docs/architecture/jgit-storage-hibernate-spike.md`.

--- a/docs/architecture/jgit-storage-hibernate-spike.md
+++ b/docs/architecture/jgit-storage-hibernate-spike.md
@@ -1,0 +1,156 @@
+# Spike: JGit/Hibernate storage consolidation
+
+Status: Proposed  
+Related ADR: `docs/architecture/adr-006-versioned-collaborative-workflow-store.md`
+
+## Goal
+
+Determine whether the Hibernate-backed JGit storage code can be consolidated as a reusable module without requiring Audio Analyzer to fork or patch JGit.
+
+The desired result is a separate infrastructure component, tentatively named `jgit-storage-hibernate` or `hibernate-jgit-store`, that can be used by Audio Analyzer, Taxonomy and Sandbox.
+
+## Why this spike comes first
+
+The collaborative workflow editor depends on transactional version storage. If the storage layer is copied into Audio Analyzer too early, the same low-level code will diverge across projects and become harder to test.
+
+This spike must answer one question before larger editor work starts:
+
+```text
+Can the DB-backed JGit store be implemented as an external module against a regular JGit release?
+```
+
+If the answer is no, the spike must identify the smallest required JGit API or core change.
+
+## Scope
+
+Included:
+
+- extract or re-create a neutral Hibernate-backed JGit storage prototype;
+- compile it against a regular JGit artifact where possible;
+- write/read blobs, trees, commits, refs and reflog entries through JGit APIs;
+- prove transactional ref update behavior;
+- document whether JGit internals are unavoidable;
+- expose only a narrow facade to Audio Analyzer.
+
+Excluded:
+
+- graphical editor implementation;
+- audio DSP execution;
+- full workflow DSL;
+- ActiveMQ/WebSocket integration;
+- full Hibernate Search history model.
+
+## Candidate facade
+
+Audio Analyzer should depend on a facade similar to this, not directly on JGit DFS classes:
+
+```java
+public interface VersionedWorkflowStore {
+    CommitId commit(String branch, WorkflowSnapshot snapshot, CommitMetadata metadata);
+
+    WorkflowSnapshot loadAtCommit(CommitId commitId);
+
+    WorkflowSnapshot loadHead(String branch);
+
+    RefUpdateResult updateRef(String refName, CommitId expectedOldCommit, CommitId newCommit);
+
+    List<CommitInfo> history(String refName, int limit);
+}
+```
+
+The storage module may internally use `DfsRepository`, `DfsObjDatabase`, `DfsReftableDatabase` or related classes, but those types must not appear in Audio Analyzer public APIs.
+
+## Required technical proof
+
+### 1. Minimal repository lifecycle
+
+Prove:
+
+```text
+create repository
+write blob
+write tree
+write commit
+update refs/heads/main or refs/heads/master
+read commit through ref
+read blob through tree
+create second commit
+traverse history
+```
+
+### 2. Atomic ref update
+
+Concurrent writers must not cause lost updates.
+
+Test shape:
+
+```text
+base: main -> C1
+thread A: expects C1, wants C2
+thread B: expects C1, wants C3
+expected: exactly one update succeeds; the other observes a conflict
+```
+
+### 3. Transaction rollback
+
+Prove there is no visible half-state when failures happen after writing objects but before updating refs or publishing outbox events.
+
+Failure cases:
+
+```text
+fail after blob/tree/commit write, before ref update
+fail after ref update, before operation log append
+fail after operation log append, before outbox event insert
+fail before transaction commit
+```
+
+The final design may choose compensation instead of one large transaction, but the behavior must be deterministic and documented.
+
+### 4. Reflog behavior
+
+Clarify:
+
+- whether reflog entries are written by JGit automatically for the chosen storage path;
+- whether reflog writes are in the same transactional unit as ref updates;
+- whether reflog can support later audit/search projections;
+- what happens on rollback.
+
+### 5. Cache and restart behavior
+
+Prove:
+
+- repository can be closed and reopened;
+- JVM/Spring context restart does not expose stale pack data;
+- multiple logical repositories can coexist in the same database;
+- pack names do not collide;
+- JGit DFS block cache does not leak stale data between tests or repositories.
+
+### 6. Data-size boundary
+
+Document that large audio recordings are not stored as Git blobs in this store. Workflow DSL, layout, metadata and small presets may be versioned; large `.aar` recordings or evidence bundles should remain external assets referenced by content hash or metadata.
+
+## Acceptance criteria
+
+- [ ] A neutral storage module exists or a precise extraction plan is documented.
+- [ ] The module either compiles against regular JGit or identifies the exact required fork/API delta.
+- [ ] Blob/tree/commit/ref roundtrip is tested.
+- [ ] Atomic ref update is tested.
+- [ ] Rollback/half-state behavior is tested or explicitly rejected with a documented reason.
+- [ ] Reflog behavior is documented.
+- [ ] Restart/cache behavior is tested.
+- [ ] Audio Analyzer public APIs do not expose JGit internal classes.
+- [ ] A follow-up issue exists for the vertical `Input -> Gain -> Output` workflow store slice.
+
+## Decision outcomes
+
+### Outcome A: regular JGit is sufficient
+
+Proceed with a separate `jgit-storage-hibernate` module and pin a tested JGit version. Keep upgrade compatibility tests.
+
+### Outcome B: regular JGit is insufficient but a small API change would solve it
+
+Document the missing extension point, keep the Audio Analyzer facade unchanged, and decide whether to maintain a minimal fork or prepare an upstream contribution.
+
+### Outcome C: the storage path is too fragile
+
+Do not build the collaborative editor on this storage layer yet. Re-scope to a simpler operation-log-first persistence model and revisit DB-backed Git later.


### PR DESCRIPTION
## Summary

This PR records the architecture decision for the future versioned collaborative workflow store and aligns the existing workflow-drawing documentation around that decision.

It deliberately avoids production-code changes and direct commits to `master`.

## Added / updated docs

- Added `docs/architecture/README.md` as the architecture-document map and authority guide.
- Added `docs/architecture/adr-006-versioned-collaborative-workflow-store.md`.
- Added `docs/architecture/jgit-storage-hibernate-spike.md`.
- Reworked `docs/architecture/collaborative-workflow-platform.md` so it no longer presents a conflicting React Flow/Yjs-first architecture as canonical.

## Key decision

- Do not copy the Hibernate-backed JGit storage code into Audio Analyzer.
- Consolidate it as a reusable `jgit-storage-hibernate` / `hibernate-jgit-store` component.
- Keep Audio Analyzer behind a narrow versioned workflow persistence facade.
- Start without a strategic JGit fork, but isolate JGit-internal API usage as a spike risk.
- Build the future collaborative graph editor web-first, with server-authoritative operations and explicit private/shared undo modes.
- Treat GLSP as the serious model-driven editor spike and React Flow as an optional fast UX prototype.

## Documentation consistency cleanup

The previous `collaborative-workflow-platform.md` contained useful scenarios, but it also implied that Yjs was the primary collaboration model and React Flow was the recommended canonical frontend stack. That conflicted with ADR-006.

The updated document now distinguishes:

- source of truth: `audio-core` workflow model + semantic operations;
- durable history: deterministic DSL + JGit checkpoints;
- live transport: operation events via outbox/broker/WebSocket;
- client UI: derived web editor state;
- optional helpers: Yjs/React Flow only where they do not become canonical persistence.

## Related issue

Related to #202.

## Validation

Docs-only change. No production code or tests changed.